### PR TITLE
update seed data to match User accounts to Member accounts, Redirect on register, and Delete

### DIFF
--- a/CarPoolLibrary/Data/SeedData.cs
+++ b/CarPoolLibrary/Data/SeedData.cs
@@ -67,10 +67,47 @@ public static class SeedData
         passengerUser.NormalizedUserName = passengerUser.Email.ToUpper();
         passengerUser.PasswordHash = passwordHasher.HashPassword(passengerUser, pwd);
 
+        var passengerUserSam = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserName = "sam@fox.com",
+            Email = "sam@fox.com",
+            EmailConfirmed = true,
+            FirstName = "Sam",
+            LastName = "Fox"
+        };
+        passengerUserSam.NormalizedUserName = passengerUserSam.Email.ToUpper();
+        passengerUserSam.PasswordHash = passwordHasher.HashPassword(passengerUserSam, pwd);
+
+        var passengerUserAnn = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserName = "ann@day.com",
+            Email = "ann@day.com",
+            EmailConfirmed = true,
+            FirstName = "Ann",
+            LastName = "Day"
+        };
+        passengerUserSam.NormalizedUserName = passengerUserSam.Email.ToUpper();
+        passengerUserSam.PasswordHash = passwordHasher.HashPassword(passengerUserSam, pwd);
+
+        var passengerUserLucas = new User
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserName = "lucas@jian.com",
+            Email = "lucas@jian.com",
+            EmailConfirmed = true,
+            FirstName = "Lucas",
+            LastName = "Jian"
+        };
+
         List<User> users = new List<User>(){
             adminUser,
             ownerUser,
-            passengerUser
+            passengerUser,
+            passengerUserSam,
+            passengerUserAnn,
+            passengerUserLucas
         };
 
         modelBuilder.Entity<User>().HasData(users);
@@ -92,6 +129,24 @@ public static class SeedData
         userRoles.Add(new IdentityUserRole<string>
         {
             UserId = users[2].Id,
+            RoleId = roles.First(q => q.Name == "Passenger").Id
+        });
+
+        userRoles.Add(new IdentityUserRole<string>
+        {
+            UserId = users[3].Id,
+            RoleId = roles.First(q => q.Name == "Passenger").Id
+        });
+
+        userRoles.Add(new IdentityUserRole<string>
+        {
+            UserId = users[4].Id,
+            RoleId = roles.First(q => q.Name == "Passenger").Id
+        });
+
+        userRoles.Add(new IdentityUserRole<string>
+        {
+            UserId = users[5].Id,
             RoleId = roles.First(q => q.Name == "Passenger").Id
         });
 

--- a/CarPoolMvc/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/CarPoolMvc/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -109,6 +109,11 @@ namespace CarPoolMvc.Areas.Identity.Pages.Account
         public async Task<IActionResult> OnPostAsync(string returnUrl = null)
         {
             returnUrl ??= Url.Content("~/");
+
+            //redirect user to complete the Member page after successful User signup
+            //this is a temp solution to generate an associated Member record for the User record
+            string redirectToMembersPage = "/Members/Create";
+
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
             if (ModelState.IsValid)
             {
@@ -154,7 +159,7 @@ namespace CarPoolMvc.Areas.Identity.Pages.Account
                     else
                     {
                         await _signInManager.SignInAsync(user, isPersistent: false);
-                        return LocalRedirect(returnUrl);
+                        return LocalRedirect(Url.Content(redirectToMembersPage));
                     }
                 }
                 foreach (var error in result.Errors)

--- a/CarPoolMvc/Controllers/MembersController.cs
+++ b/CarPoolMvc/Controllers/MembersController.cs
@@ -8,26 +8,37 @@ using Microsoft.EntityFrameworkCore;
 using CarPoolLibrary.Models;
 using CarPoolLibrary.Data;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 
 namespace CarPoolMvc.Controllers
 {
-    [Authorize(Roles = "Admin")]
     public class MembersController : Controller
     {
         private readonly ApplicationDbContext _context;
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
+        private readonly ILogger<UsersController> _logger;
 
-        public MembersController(ApplicationDbContext context)
+        public MembersController(ApplicationDbContext context, 
+            UserManager<IdentityUser> userManager, 
+            RoleManager<IdentityRole> roleManager,
+            ILogger<UsersController> logger)
         {
             _context = context;
+            _userManager = userManager;
+            _roleManager = roleManager;
+            _logger = logger;
         }
 
         // GET: Members
+        [Authorize(Roles="Admin")]
         public async Task<IActionResult> Index()
         {
             return View(await _context.Members!.ToListAsync());
         }
 
         // GET: Members/Details/5
+        [Authorize(Roles="Admin")]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -46,8 +57,10 @@ namespace CarPoolMvc.Controllers
         }
 
         // GET: Members/Create
+        [Authorize(Roles="Admin, Passenger")]
         public IActionResult Create()
         {
+            
             return View();
         }
 
@@ -56,18 +69,20 @@ namespace CarPoolMvc.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles="Admin, Passenger")]
         public async Task<IActionResult> Create([Bind("MemberId,FirstName,LastName,Email,Mobile,Street,City,PostalCode,Country,Created,Modified,CreatedBy,ModifiedBy")] Member member)
         {
             if (ModelState.IsValid)
             {
                 _context.Add(member);
                 await _context.SaveChangesAsync();
-                return RedirectToAction(nameof(Index));
+                return RedirectToAction("Index", "Home");
             }
             return View(member);
         }
 
         // GET: Members/Edit/5
+        [Authorize(Roles="Admin")]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -88,6 +103,7 @@ namespace CarPoolMvc.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles="Admin")]
         public async Task<IActionResult> Edit(int id, [Bind("MemberId,FirstName,LastName,Email,Mobile,Street,City,PostalCode,Country,Created,Modified,CreatedBy,ModifiedBy")] Member member)
         {
             if (id != member.MemberId)
@@ -139,12 +155,42 @@ namespace CarPoolMvc.Controllers
         // POST: Members/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
+        [Authorize(Roles="Admin")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
             var member = await _context.Members!.FindAsync(id);
             if (member != null)
             {
+
+                // Get the email of the currently logged in user
+                var loggedInUserEmail = User.Identity?.Name;
+                // Compare the email of the Member to be deleted with the email of the currently logged in user
+                if (member.Email == loggedInUserEmail)
+                {
+                    // Return an error message if they are the same
+                    ModelState.AddModelError(string.Empty, "You cannot delete the account of the currently logged in user.");
+                    _logger.LogWarning("User tried to delete their own account.");
+                    return RedirectToAction(nameof(Index));
+                }
+
                 _context.Members.Remove(member);
+                await _context.SaveChangesAsync();
+
+                // Find the User with the same email as the Member
+                var user = await _userManager.FindByEmailAsync(member.Email!);
+                if (user != null)
+                {
+                    // Delete the User with the same email as the Member
+                    var result = await _userManager.DeleteAsync(user);
+                    if (!result.Succeeded)
+                    {
+                        foreach (var error in result.Errors)
+                        {
+                            ModelState.AddModelError(string.Empty, error.Description);
+                        }
+                        return View();
+                    }
+                }
             }
 
             await _context.SaveChangesAsync();

--- a/CarPoolMvc/Views/Members/Create.cshtml
+++ b/CarPoolMvc/Views/Members/Create.cshtml
@@ -24,7 +24,13 @@
             </div>
             <div class="form-group">
                 <label asp-for="Email" class="control-label"></label>
-                <input asp-for="Email" class="form-control" />
+                @if (User.Identity!.IsAuthenticated)
+                {
+                    <input asp-for="Email" class="form-control" value="@User.Identity.Name" />
+                } else
+                {
+                    <input asp-for="Email" class="form-control" />
+                }
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
             <div class="form-group">


### PR DESCRIPTION
- Added more User accounts in SeedData to match Members
- When a user registers an account, they get redirected to the Member/Create page to fill in their info --> a Member entity is then created
- Added methods to the UserController and MemberController so that when a user deletes the User account, it gets reflected in Members page as well (and vice versa)

TODO: Update the edit to reflect the changes from User details to Member details

https://github.com/lucasj8018/Asst1-CarPool/assets/97325915/f94d8c40-0029-4a9d-8709-0f04b2acc820

